### PR TITLE
DB forensics tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ GOTOOLS := github.com/golang/dep/cmd/dep
 
 PDFFLAGS := -pdf --nodefraction=0.1
 
-all: get_vendor_deps test
+all: get_vendor_deps test install
+
+install:
+	go install ./cmd/iaviewer
 
 test:
 	GOCACHE=off go test -v --race

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -3,9 +3,86 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
+
+	"github.com/tendermint/iavl"
+	dbm "github.com/tendermint/tendermint/libs/db"
+)
+
+// TODO: make these configurable?
+const (
+	DefaultCacheSize int = 10000
 )
 
 func main() {
-	fmt.Println("welcome home")
-	fmt.Println(os.Args[1:])
+	args := os.Args[1:]
+	if len(args) != 1 {
+		fmt.Println("Usage: iaviewer <leveldb dir>")
+		os.Exit(1)
+	}
+	tree, err := ReadTree(args[0])
+	if err != nil {
+		fmt.Printf("Error reading data: %s\n", err)
+		os.Exit(2)
+	}
+	fmt.Printf("Successfully read tree in %s\n", args[0])
+	fmt.Printf("  Hash: %X\n", tree.Hash())
+	PrintKeys(tree)
+}
+
+func OpenDb(dir string) (dbm.DB, error) {
+	if strings.HasSuffix(dir, ".db") {
+		dir = dir[:len(dir)-3]
+	} else if strings.HasSuffix(dir, ".db/") {
+		dir = dir[:len(dir)-4]
+	} else {
+		return nil, fmt.Errorf("Database directory must end with .db")
+	}
+	// TODO: doesn't work on windows!
+	cut := strings.LastIndex(dir, "/")
+	if cut == -1 {
+		return nil, fmt.Errorf("Cannot cut paths on %s", dir)
+	}
+	name := dir[cut+1:]
+	fmt.Println(dir[:cut], name)
+	db, err := dbm.NewGoLevelDB(name, dir[:cut])
+	if err != nil {
+		return nil, err
+	}
+	PrintDbStats(db)
+	return db, nil
+}
+
+func PrintDbStats(db dbm.DB) {
+	// stats, _ := json.MarshalIndent(db.Stats(), "", "  ")
+	// fmt.Println(string(stats))
+
+	count := 0
+	prefix := map[string]int{}
+	iter := db.Iterator(nil, nil)
+	for ; iter.Valid(); iter.Next() {
+		key := string(iter.Key()[:1])
+		prefix[key] = prefix[key] + 1
+		count++
+	}
+	iter.Close()
+	fmt.Printf("DB contains %d entries\n", count)
+	for k, v := range prefix {
+		fmt.Printf("  %s: %d\n", k, v)
+	}
+}
+
+func ReadTree(dir string) (*iavl.MutableTree, error) {
+	db, err := OpenDb(dir)
+	if err != nil {
+		return nil, err
+	}
+	tree := iavl.NewMutableTree(db, DefaultCacheSize)
+	ver, err := tree.Load()
+	fmt.Printf("Got version: %d\n", ver)
+	return tree, err
+}
+
+func PrintKeys(tree *iavl.MutableTree) {
+	fmt.Println("Printing all keys")
 }

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -139,8 +139,20 @@ func encodeId(id []byte) string {
 }
 
 func PrintShape(tree *iavl.MutableTree) {
-	shape := tree.RenderShape("  ", parseWeaveKey)
+	// shape := tree.RenderShape("  ", nil)
+	shape := tree.RenderShape("  ", nodeEncoder)
 	fmt.Println(strings.Join(shape, "\n"))
+}
+
+func nodeEncoder(id []byte, depth int, isLeaf bool) string {
+	prefix := fmt.Sprintf("-%d ", depth)
+	if isLeaf {
+		prefix = fmt.Sprintf("*%d ", depth)
+	}
+	if len(id) == 0 {
+		return fmt.Sprintf("%s<nil>", prefix)
+	}
+	return fmt.Sprintf("%s%s", prefix, parseWeaveKey(id))
 }
 
 func PrintVersions(tree *iavl.MutableTree) {

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -156,7 +156,7 @@ func nodeEncoder(id []byte, depth int, isLeaf bool) string {
 }
 
 func PrintVersions(tree *iavl.MutableTree) {
-	versions := tree.GetVersions()
+	versions := tree.AvailableVersions()
 	fmt.Println("Available versions:")
 	for _, v := range versions {
 		fmt.Printf("  %d\n", v)

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -19,21 +19,25 @@ const (
 
 func main() {
 	args := os.Args[1:]
-	if len(args) != 1 {
-		fmt.Println("Usage: iaviewer <leveldb dir>")
+	if len(args) != 2 || (args[0] != "data" && args[0] != "shape") {
+		fmt.Println("Usage: iaviewer [data|shape] <leveldb dir>")
 		os.Exit(1)
 	}
-	tree, err := ReadTree(args[0])
+
+	tree, err := ReadTree(args[1])
 	if err != nil {
 		fmt.Printf("Error reading data: %s\n", err)
 		os.Exit(2)
 	}
 	fmt.Printf("Successfully read tree in %s\n", args[0])
 
-	PrintKeys(tree)
-
-	fmt.Printf("Hash: %X\n", tree.Hash())
-	fmt.Printf("Size: %X\n", tree.Size())
+	if args[0] == "data" {
+		PrintKeys(tree)
+		fmt.Printf("Hash: %X\n", tree.Hash())
+		fmt.Printf("Size: %X\n", tree.Size())
+	} else if args[0] == "shape" {
+		PrintShape(tree)
+	}
 }
 
 func OpenDb(dir string) (dbm.DB, error) {
@@ -118,4 +122,17 @@ func encodeId(id []byte) string {
 		}
 	}
 	return string(id)
+}
+
+func PrintShape(tree *iavl.MutableTree) error {
+	_, _, proof, err := tree.GetRangeWithProof(nil, nil, 0)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Left path: %s\n", proof.LeftPath)
+	for i, p := range proof.InnerNodes {
+		fmt.Printf("%d: %s\n", i, p)
+	}
+	return nil
 }

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("welcome home")
+	fmt.Println(os.Args[1:])
+}

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -12,7 +12,7 @@ import (
 	dbm "github.com/tendermint/tendermint/libs/db"
 )
 
-// TODO: make these configurable?
+// TODO: make this configurable?
 const (
 	DefaultCacheSize int = 10000
 )
@@ -29,7 +29,6 @@ func main() {
 		fmt.Printf("Error reading data: %s\n", err)
 		os.Exit(2)
 	}
-	fmt.Printf("Successfully read tree in %s\n", args[0])
 
 	if args[0] == "data" {
 		PrintKeys(tree)
@@ -58,7 +57,7 @@ func OpenDb(dir string) (dbm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	PrintDbStats(db)
+	// PrintDbStats(db)
 	return db, nil
 }
 
@@ -124,15 +123,18 @@ func encodeId(id []byte) string {
 	return string(id)
 }
 
-func PrintShape(tree *iavl.MutableTree) error {
-	_, _, proof, err := tree.GetRangeWithProof(nil, nil, 0)
-	if err != nil {
-		return err
-	}
+func PrintShape(tree *iavl.MutableTree) {
+	shape := tree.RenderShape("  ", parseWeaveKey)
+	fmt.Println(strings.Join(shape, "\n"))
 
-	fmt.Printf("Left path: %s\n", proof.LeftPath)
-	for i, p := range proof.InnerNodes {
-		fmt.Printf("%d: %s\n", i, p)
-	}
-	return nil
+	// _, _, proof, err := tree.GetRangeWithProof(nil, nil, 0)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// fmt.Printf("Left path: %s\n", proof.LeftPath)
+	// for i, p := range proof.InnerNodes {
+	// 	fmt.Printf("%d: %s\n", i, p)
+	// }
+	// return nil
 }

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -126,15 +126,4 @@ func encodeId(id []byte) string {
 func PrintShape(tree *iavl.MutableTree) {
 	shape := tree.RenderShape("  ", parseWeaveKey)
 	fmt.Println(strings.Join(shape, "\n"))
-
-	// _, _, proof, err := tree.GetRangeWithProof(nil, nil, 0)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// fmt.Printf("Left path: %s\n", proof.LeftPath)
-	// for i, p := range proof.InnerNodes {
-	// 	fmt.Printf("%d: %s\n", i, p)
-	// }
-	// return nil
 }

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -53,16 +53,16 @@ func (t *ImmutableTree) renderNode(node *Node, indent string, depth int, encoder
 		return []string{fmt.Sprintf("%s<nil>", strings.Repeat(indent, depth))}
 	}
 	// print this one
-	here := fmt.Sprintf("%s%s", strings.Repeat(indent, depth), node.CompactString(encoder))
+	here := fmt.Sprintf("%s%d %s", strings.Repeat(indent, depth), depth, node.CompactString(encoder))
 
 	if node.isLeaf() {
 		return []string{here}
 	}
 
-	right := t.renderNode(node.getRightNode(t), indent, depth+1, encoder)
 	left := t.renderNode(node.getLeftNode(t), indent, depth+1, encoder)
-	result := append(right, here)
-	result = append(result, left...)
+	right := t.renderNode(node.getRightNode(t), indent, depth+1, encoder)
+	result := append(left, here)
+	result = append(result, right...)
 	return result
 }
 

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -1,6 +1,7 @@
 package iavl
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -36,6 +37,33 @@ func (t *ImmutableTree) String() string {
 		return false
 	})
 	return "Tree{" + strings.Join(leaves, ", ") + "}"
+}
+
+// RenderShape provides a nested tree shape, ident is prepended in each level
+// Returns an array of strings, one per line, to join with "\n" or display otherwise
+func (t *ImmutableTree) RenderShape(indent string, encoder func([]byte) string) []string {
+	if encoder == nil {
+		encoder = hex.EncodeToString
+	}
+	return t.renderNode(t.root, indent, 0, encoder)
+}
+
+func (t *ImmutableTree) renderNode(node *Node, indent string, depth int, encoder func([]byte) string) []string {
+	if node == nil {
+		return []string{fmt.Sprintf("%s<nil>", strings.Repeat(indent, depth))}
+	}
+	// print this one
+	here := fmt.Sprintf("%s%s", strings.Repeat(indent, depth), node.CompactString(encoder))
+
+	if node.isLeaf() {
+		return []string{here}
+	}
+
+	right := t.renderNode(node.getRightNode(t), indent, depth+1, encoder)
+	left := t.renderNode(node.getLeftNode(t), indent, depth+1, encoder)
+	result := append(right, here)
+	result = append(result, left...)
+	return result
 }
 
 // Size returns the number of leaf nodes in the tree.

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -46,8 +46,8 @@ func (tree *MutableTree) VersionExists(version int64) bool {
 	return tree.versions[version]
 }
 
-// GetVersions returns all available versions
-func (tree *MutableTree) GetVersions() []int {
+// AvailableVersions returns all available versions
+func (tree *MutableTree) AvailableVersions() []int {
 	res := make([]int, 0, len(tree.versions))
 	for i, v := range tree.versions {
 		if v {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -3,6 +3,7 @@ package iavl
 import (
 	"bytes"
 	"fmt"
+	"sort"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
@@ -43,6 +44,18 @@ func (tree *MutableTree) IsEmpty() bool {
 // VersionExists returns whether or not a version exists.
 func (tree *MutableTree) VersionExists(version int64) bool {
 	return tree.versions[version]
+}
+
+// GetVersions returns all available versions
+func (tree *MutableTree) GetVersions() []int {
+	res := make([]int, 0, len(tree.versions))
+	for i, v := range tree.versions {
+		if v {
+			res = append(res, int(i))
+		}
+	}
+	sort.Sort(sort.IntSlice(res))
+	return res
 }
 
 // Hash returns the hash of the latest saved version of the tree, as returned
@@ -270,7 +283,7 @@ func (tree *MutableTree) LoadVersionForOverwriting(targetVersion int64) (int64, 
 	if err != nil {
 		return latestVersion, err
 	}
-	tree.deleteVersionsFrom(targetVersion+1)
+	tree.deleteVersionsFrom(targetVersion + 1)
 	return targetVersion, nil
 }
 

--- a/node.go
+++ b/node.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
@@ -114,6 +114,19 @@ func (node *Node) String() string {
 		node.version,
 		node.leftHash, node.rightHash,
 		hashstr)
+}
+
+func (node *Node) CompactString(encoder func([]byte) string) string {
+	if node == nil {
+		return "<nil>"
+	}
+	if !node.isLeaf() {
+		if len(node.hash) > 0 {
+			return fmt.Sprintf("- %X", node.hash)
+		}
+		return "- <no hash>"
+	}
+	return fmt.Sprintf("* %s", encoder(node.key))
 }
 
 // clone creates a shallow copy of a node with its hash set to nil.

--- a/node.go
+++ b/node.go
@@ -116,19 +116,6 @@ func (node *Node) String() string {
 		hashstr)
 }
 
-func (node *Node) CompactString(encoder func([]byte) string) string {
-	if node == nil {
-		return "<nil>"
-	}
-	if !node.isLeaf() {
-		if len(node.hash) > 0 {
-			return fmt.Sprintf("- %X", node.hash)
-		}
-		return "- <no hash>"
-	}
-	return fmt.Sprintf("* %s", encoder(node.key))
-}
-
 // clone creates a shallow copy of a node with its hash set to nil.
 func (node *Node) clone(version int64) *Node {
 	if node.isLeaf() {


### PR DESCRIPTION
Our nodes fell out of consensus due to inconsistent app hashes, but after locating the transaction that caused it and finding no obvious issues in the execution path, we had no real tools to figure out what the problem was.

I add a new command `cmd/iaviewer` that can also be installed via `make install` to allow forensic analysis and comparison of leveldb-backed iavl trees

We also allow an optional third argument of a version number to specify an older version of the state to use, rather than the latest one. This is interesting if you want to see what things looked like right *before* it all went wrong.

Done:

`iaviewer data <path to db> [version]`

Prints out version, hash, size as well as every key along with a hash of the data (to keep sizes small). We try to convert as much of the key to ascii if possible, in case the app is using human-readble strings. The data is hashed, as the only thing we cared about at this point was if one key had a different value on two different nodes.

`iaviewer shape <path to db> [version]`

It is possible for two trees to have a different hash even with the same data if the insert order is different. This attempts to visualize the tree structure to locate the difference.

`iaviewer versions <path to db>`

Lists all available versions in the db, so we can compare snapshots from different points in time.

Later:

* Comparison of the shape of two different databases?